### PR TITLE
Bump asyncpg to version 0.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/sivakov512/asyncpg-engine"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-asyncpg = "^0.25.0"
+asyncpg = "^0.27.0"
 pytest = {version = "^7.0.0", optional = true}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Bump asyncpg to version 0.27
  
This version works with Python 3.11.
